### PR TITLE
Fix: Unify call and tail call handling; remove trampoline toggle

### DIFF
--- a/lua/src/commonMain/kotlin/ai/tenum/lua/vm/LuaVmImpl.kt
+++ b/lua/src/commonMain/kotlin/ai/tenum/lua/vm/LuaVmImpl.kt
@@ -211,9 +211,9 @@ class LuaVmImpl(
 
     /**
      * Call depth counter for stack overflow detection.
-     * Tracks recursive call depth to prevent native stack overflow.
+     * Tracks the depth of the trampoline execution stack to prevent unbounded growth.
      * Matches Lua 5.4's LUAI_MAXCCALLS behavior (typically 200 for testing, 1000+ for production).
-     * Note: Tail calls use trampoline and don't increment this counter.
+     * All Lua function calls (including tail calls) use the trampoline loop.
      */
     private var callDepth = 0
     private val maxCallDepth = 1000
@@ -286,8 +286,6 @@ class LuaVmImpl(
         set(value) {
             debugTracer.debugLogger = value
         }
-
-    fun enableTrampoline(enabled: Boolean) = debugTracer.enableTrampoline(enabled)
 
     fun enableRegisterTrace(index: Int?) = debugTracer.enableRegisterTrace(index)
 

--- a/lua/src/commonMain/kotlin/ai/tenum/lua/vm/debug/DebugTracer.kt
+++ b/lua/src/commonMain/kotlin/ai/tenum/lua/vm/debug/DebugTracer.kt
@@ -8,7 +8,6 @@ import ai.tenum.lua.runtime.LuaValue
  * Handles:
  * - Debug logging with configurable output
  * - Register write tracing for debugging
- * - Trampoline tail-call optimization control
  */
 class DebugTracer {
     /**
@@ -25,11 +24,6 @@ class DebugTracer {
      * Register index to trace writes (null = no tracing)
      */
     private var traceRegisterIndex: Int? = null
-
-    /**
-     * Trampoline tail-call optimization enabled/disabled
-     */
-    private var trampolineEnabled: Boolean = true
 
     /**
      * Enable debug logging with optional custom logger.
@@ -61,21 +55,6 @@ class DebugTracer {
             debugLogger(messageBuilder())
         }
     }
-
-    /**
-     * Enable/disable trampoline tail-call optimization.
-     *
-     * @param enabled true to enable TCO, false to disable
-     */
-    fun enableTrampoline(enabled: Boolean) {
-        trampolineEnabled = enabled
-        debug { "Trampoline TCO ${if (enabled) "enabled" else "disabled"}" }
-    }
-
-    /**
-     * Check if trampoline TCO is enabled.
-     */
-    fun isTrampolineEnabled(): Boolean = trampolineEnabled
 
     /**
      * Enable register write tracing for a specific register index.


### PR DESCRIPTION
Refactored call and tail call execution to use a unified CallResult sealed class, eliminating the separate TailCallResult. Removed trampoline tail-call optimization toggling and related code, ensuring all Lua function calls (including tail calls) use the trampoline loop. Improved callable resolution logic to handle __call metamethods consistently for both CALL and TAILCALL opcodes.