### PR TITLE
Feat: fully support db lua

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,6 @@ gradle-app.setting
 **/node_modules
 
 **/*.js
+
+aidoc
+.github/copilot-instructions.md

--- a/README.md
+++ b/README.md
@@ -115,8 +115,41 @@ Keep your repos; use our hosting only if you want it.
 
 ### Now
 - ✅ Kotlin Multiplatform Lua interpreter
-- 🚧 Fix lua [Test suite](https://www.lua.org/tests/) 
-- 🚧 Continious diployment to npm
+- ✅ Continious diployment to npm
+- 🚧 Fix lua [Test suite](https://www.lua.org/tests/)
+  - ✅ **api.lua** - API compatibility tests
+  - ✅ **attrib.lua** - Attribute and metamethod tests
+  - ✅ **big.lua** - Large number handling
+  - ✅ **bitwise.lua** - Bitwise operations
+  - ✅ **bwcoercion.lua** - Bitwise coercion
+  - ✅ **calls.lua** - Function calls (partial - bytecode differences)
+  - ✅ **closure.lua** - Closures and upvalues
+  - ✅ **constructs.lua** - Language constructs
+  - ✅ **db.lua** - Debug library (partial - instruction count differences)
+  - ✅ **errors.lua** - Error handling (partial - parser limit tests skipped)
+  - ✅ **literals.lua** - Literal values (partial - string internalization differences)
+  - ✅ **main.lua** - Main entry point tests
+  - ✅ **sort.lua** - Table sorting
+  - ✅ **strings.lua** - String operations (partial - formatting differences)
+  - ✅ **tpack.lua** - Table pack/unpack
+  - ✅ **tracegc.lua** - Garbage collection traces
+  - ✅ **vararg.lua** - Variable arguments
+  - ✅ **verybig.lua** - Very large number operations
+  - ⏸️ **coroutine.lua** - Coroutines (failing at eqtab check)
+  - ❌ **code.lua** - Code generation tests
+  - ❌ **cstack.lua** - C stack tests (not applicable)
+  - ❌ **events.lua** - Event handling
+  - ❌ **files.lua** - File I/O operations
+  - ❌ **gc.lua** - Garbage collection (not implemented)
+  - ❌ **gengc.lua** - Generational GC (not implemented)
+  - ❌ **goto.lua** - Goto statements
+  - ❌ **heavy.lua** - Heavy computation tests
+  - ❌ **locals.lua** - Local variable tests
+  - ❌ **math.lua** - Math library
+  - ❌ **nextvar.lua** - Next variable iteration
+  - ❌ **pm.lua** - Pattern matching
+  - ❌ **utf8.lua** - UTF-8 support
+  - ⏭️ **all.lua** - Complete test orchestrator (skipped)
 - 🚧 Create binarry installer
   - 🚧 Windows
   - 🚧 MacOs

--- a/cli/src/commonMain/kotlin/ai/tenum/cli/commands/Luac.kt
+++ b/cli/src/commonMain/kotlin/ai/tenum/cli/commands/Luac.kt
@@ -6,6 +6,7 @@ import ai.tenum.lua.compiler.model.Proto
 import ai.tenum.lua.compiler.util.DebugInfoStripping
 import ai.tenum.lua.lexer.Lexer
 import ai.tenum.lua.parser.Parser
+import ai.tenum.lua.runtime.LuaCompiledFunction
 import com.github.ajalt.clikt.core.CliktCommand
 import com.github.ajalt.clikt.parameters.arguments.argument
 import com.github.ajalt.clikt.parameters.arguments.optional

--- a/cli/src/commonMain/kotlin/ai/tenum/cli/commands/Luac.kt
+++ b/cli/src/commonMain/kotlin/ai/tenum/cli/commands/Luac.kt
@@ -3,9 +3,9 @@ package ai.tenum.cli.commands
 import ai.tenum.lua.compiler.Compiler
 import ai.tenum.lua.compiler.io.ChunkWriter
 import ai.tenum.lua.compiler.model.Proto
+import ai.tenum.lua.compiler.util.DebugInfoStripping
 import ai.tenum.lua.lexer.Lexer
 import ai.tenum.lua.parser.Parser
-import ai.tenum.lua.runtime.LuaCompiledFunction
 import com.github.ajalt.clikt.core.CliktCommand
 import com.github.ajalt.clikt.parameters.arguments.argument
 import com.github.ajalt.clikt.parameters.arguments.optional
@@ -103,26 +103,7 @@ class Luac(
         return compiler.compile(ast, name = sourceName)
     }
 
-    private fun stripDebugInfo(proto: Proto): Proto {
-        val strippedConstants =
-            proto.constants.map { const ->
-                if (const is LuaCompiledFunction) {
-                    LuaCompiledFunction(
-                        stripDebugInfo(const.proto),
-                        const.upvalues,
-                    )
-                } else {
-                    const
-                }
-            }
-
-        return proto.copy(
-            constants = strippedConstants,
-            localVars = emptyList(),
-            lineEvents = emptyList(),
-            source = "=?",
-        )
-    }
+    private fun stripDebugInfo(proto: Proto): Proto = DebugInfoStripping.stripDebugInfo(proto)
 
     private fun listProto(
         proto: Proto,

--- a/lua/src/commonMain/kotlin/ai/tenum/lua/compiler/io/ChunkWriter.kt
+++ b/lua/src/commonMain/kotlin/ai/tenum/lua/compiler/io/ChunkWriter.kt
@@ -73,9 +73,9 @@ object ChunkWriter {
         // Source name (write the source, not the function name)
         writeString(sink, proto.source)
 
-        // Line info
-        sink.writeIntLe(proto.lineInfo.firstOrNull()?.line ?: 0) // linedefined
-        sink.writeIntLe(proto.lineInfo.lastOrNull()?.line ?: 0) // lastlinedefined
+        // Line info - write the function definition line numbers
+        sink.writeIntLe(proto.lineDefined)
+        sink.writeIntLe(proto.lastLineDefined)
 
         // Function info
         sink.writeByte(proto.parameters.size) // numparams

--- a/lua/src/commonMain/kotlin/ai/tenum/lua/compiler/util/DebugInfoStripping.kt
+++ b/lua/src/commonMain/kotlin/ai/tenum/lua/compiler/util/DebugInfoStripping.kt
@@ -1,0 +1,56 @@
+package ai.tenum.lua.compiler.util
+
+import ai.tenum.lua.compiler.model.Proto
+import ai.tenum.lua.runtime.LuaCompiledFunction
+
+/**
+ * Utility for stripping debug information from compiled Lua functions.
+ * Used by string.dump() and luac compiler.
+ */
+object DebugInfoStripping {
+    /**
+     * Recursively strips debug information from a Proto and all nested function constants.
+     *
+     * Stripped fields:
+     * - localVars: Set to empty list (local variable names and scopes)
+     * - lineEvents: Set to empty list (PC → line mappings)
+     * - source: Changed to "=?" (source file name)
+     * - upvalueInfo names: Set to empty string except for "_ENV" (needed for environment binding)
+     *
+     * Preserved fields:
+     * - lineDefined, lastLineDefined: Function definition line numbers (for debug.getinfo)
+     * - instructions, constants, parameters, upvalue structure
+     */
+    fun stripDebugInfo(proto: Proto): Proto {
+        val strippedConstants =
+            proto.constants.map { const ->
+                if (const is LuaCompiledFunction) {
+                    LuaCompiledFunction(
+                        stripDebugInfo(const.proto),
+                        const.upvalues,
+                    )
+                } else {
+                    const
+                }
+            }
+
+        // Strip upvalue names, but preserve "_ENV" which is needed for environment binding
+        // (see BasicLibLoading.kt line 392 which searches for "_ENV" by name)
+        val strippedUpvalues =
+            proto.upvalueInfo.map { upval ->
+                val newName = if (upval.name == "_ENV") "_ENV" else ""
+                upval.copy(name = newName)
+            }
+
+        return proto.copy(
+            constants = strippedConstants,
+            upvalueInfo = strippedUpvalues,
+            localVars = emptyList(),
+            lineEvents = emptyList(),
+            source = "=?",
+            // Preserve lineDefined and lastLineDefined for debug.getinfo
+            lineDefined = proto.lineDefined,
+            lastLineDefined = proto.lastLineDefined,
+        )
+    }
+}

--- a/lua/src/commonMain/kotlin/ai/tenum/lua/stdlib/string/StringLib.kt
+++ b/lua/src/commonMain/kotlin/ai/tenum/lua/stdlib/string/StringLib.kt
@@ -1,6 +1,7 @@
 package ai.tenum.lua.stdlib.string
 
 import ai.tenum.lua.compiler.io.ChunkWriter
+import ai.tenum.lua.compiler.util.DebugInfoStripping
 import ai.tenum.lua.runtime.LuaBoolean
 import ai.tenum.lua.runtime.LuaCompiledFunction
 import ai.tenum.lua.runtime.LuaDouble
@@ -358,10 +359,7 @@ class StringLib : LuaLibrary {
         // If stripping debug info, create a modified proto
         val proto =
             if (strip) {
-                originalProto.copy(
-                    source = "=?",
-                    lineEvents = emptyList(),
-                )
+                DebugInfoStripping.stripDebugInfo(originalProto)
             } else {
                 originalProto
             }

--- a/lua/src/commonTest/kotlin/ai/tenum/lua/compat/BinaryChunkSizeTest.kt
+++ b/lua/src/commonTest/kotlin/ai/tenum/lua/compat/BinaryChunkSizeTest.kt
@@ -1,0 +1,47 @@
+package ai.tenum.lua.compat
+
+import kotlin.test.Test
+
+/**
+ * Test for db.lua:1033 - binary chunk with long source name should not duplicate source in nested functions
+ */
+class BinaryChunkSizeTest : LuaCompatTestBase() {
+    @Test
+    fun testBinaryChunkSizeWithLongSourceName() =
+        runTest {
+            // Test from db.lua:1022-1039
+            // Binary chunk should not repeat the source name for each nested function
+            execute(
+                """
+                local prog = [[
+                  return function (x)
+                    return function (y) 
+                      return x + y
+                    end
+                  end
+                ]]
+                local name = string.rep("x", 1000)
+                local p = assert(load(prog, name))
+                
+                -- Load 'p' as a binary chunk with debug information
+                local c = string.dump(p)
+                
+                -- The chunk should be > 1000 bytes but < 2000 bytes
+                -- This ensures that the source name (1000 'x' chars) is not repeated for each nested function
+                assert(#c > 1000, "Chunk size should be > 1000, got: " .. #c)
+                assert(#c < 2000, "Chunk size should be < 2000, got: " .. #c .. " (source name may be duplicated for nested functions)")
+                
+                -- Verify the function still works
+                local f = assert(load(c))
+                local g = f()
+                local h = g(3)
+                assert(h(5) == 8, "Function should work correctly")
+                
+                -- Verify all functions have the correct source
+                assert(debug.getinfo(f).source == name, "f should have source = name")
+                assert(debug.getinfo(g).source == name, "g should have source = name")
+                assert(debug.getinfo(h).source == name, "h should have source = name")
+                """,
+            )
+        }
+}

--- a/lua/src/commonTest/kotlin/ai/tenum/lua/compat/stdlib/debug/LineHookStrippedDebugInfoTest.kt
+++ b/lua/src/commonTest/kotlin/ai/tenum/lua/compat/stdlib/debug/LineHookStrippedDebugInfoTest.kt
@@ -1,0 +1,76 @@
+package ai.tenum.lua.compat.stdlib.debug
+
+import ai.tenum.lua.compat.LuaCompatTestBase
+import kotlin.test.Test
+
+/**
+ * Test for line hooks with stripped debug information.
+ *
+ * This tests the Lua 5.4.0 bug fix: line hooks in stripped code should fire
+ * but receive nil as the line parameter (not a number).
+ *
+ * Test based on db.lua:1004-1019
+ */
+class LineHookStrippedDebugInfoTest : LuaCompatTestBase() {
+    @Test
+    fun testLineHookWithStrippedDebugInfo() =
+        runTest {
+            // Test from db.lua:1004-1019
+            // When code is stripped of debug info (string.dump(func, true)),
+            // line hooks should still fire but receive nil for the line parameter
+            execute(
+                """
+                local function foo ()
+                    local a = 1
+                    local b = 2
+                    return b
+                end
+
+                local s = load(string.dump(foo, true))
+                local line = true
+                debug.sethook(function (e, l)
+                    assert(e == "line")
+                    line = l
+                end, "l")
+                assert(s() == 2); debug.sethook(nil)
+                assert(line == nil, "Hook should receive nil for line when debug info is stripped, got: " .. tostring(line))
+                """,
+            )
+        }
+
+    @Test
+    fun testLineHookWithDebugInfo() =
+        runTest {
+            // Verify that WITH debug info, line hooks receive a number (not nil)
+            execute(
+                """
+                local function foo ()
+                    local a = 1
+                    local b = 2
+                    return b
+                end
+
+                local s = load(string.dump(foo, false))  -- false = keep debug info
+                local line = nil
+                local hook_called = false
+                debug.sethook(function (e, l)
+                    assert(e == "line", "Expected event='line', got: " .. tostring(e))
+                    hook_called = true
+                    line = l  -- capture the line parameter
+                end, "l")
+                local result = s()
+                debug.sethook(nil)
+                
+                -- Result should still be correct
+                assert(result == 2, "Function should return 2, got: " .. tostring(result))
+                
+                -- Hook should have been called
+                assert(hook_called, "Hook should have been called")
+                
+                -- Line parameter should be a number when debug info is present
+                assert(type(line) == "number", "Hook should receive a number for line when debug info is present, got: " .. type(line))
+                assert(line > 0, "Line number should be > 0, got: " .. tostring(line))
+                """,
+            )
+        }
+}

--- a/tests/integration/build.gradle.kts
+++ b/tests/integration/build.gradle.kts
@@ -1,3 +1,5 @@
+import java.util.concurrent.ConcurrentHashMap
+
 plugins {
     id("tenum.conventions.mpplib")
 }
@@ -24,4 +26,65 @@ kotlin {
             }
         }
     }
+}
+
+tasks.withType<Test>().configureEach {
+    // If you use JUnit 5, keep this
+    useJUnitPlatform()
+
+    testLogging {
+        // Always show which tests passed/failed
+        events("skipped", "failed")
+
+        // Full exception stack traces for failures
+        exceptionFormat = org.gradle.api.tasks.testing.logging.TestExceptionFormat.FULL
+
+        // Only show stdout/stderr for failed tests
+        showStandardStreams = false
+    }
+    // Buffer stdout/stderr per test
+    val buffers = ConcurrentHashMap<String, StringBuilder>()
+
+    fun key(d: TestDescriptor) = "${d.className}#${d.name}"
+
+    addTestOutputListener(
+        object : TestOutputListener {
+            override fun onOutput(
+                descriptor: TestDescriptor,
+                event: TestOutputEvent,
+            ) {
+                buffers
+                    .computeIfAbsent(key(descriptor)) { StringBuilder() }
+                    .append(event.message)
+            }
+        },
+    )
+
+    addTestListener(
+        object : TestListener {
+            override fun afterTest(
+                descriptor: TestDescriptor,
+                result: TestResult,
+            ) {
+                if (result.resultType == TestResult.ResultType.FAILURE) {
+                    val k = key(descriptor)
+                    val out = buffers[k]?.toString()?.trim()
+                    if (!out.isNullOrEmpty()) {
+                        println("\n--- Captured output for FAILED test: $k ---\n$out\n")
+                    }
+                }
+                // free memory
+                buffers.remove(key(descriptor))
+            }
+
+            override fun beforeTest(descriptor: TestDescriptor) {}
+
+            override fun beforeSuite(suite: TestDescriptor) {}
+
+            override fun afterSuite(
+                suite: TestDescriptor,
+                result: TestResult,
+            ) {}
+        },
+    )
 }

--- a/tests/integration/src/jvmTest/kotlin/ai/tenum/lua/compat/integration/OfficialTestSuiteCompatTest.kt
+++ b/tests/integration/src/jvmTest/kotlin/ai/tenum/lua/compat/integration/OfficialTestSuiteCompatTest.kt
@@ -80,8 +80,6 @@ class OfficialTestSuiteCompatTest : LuaCompatTestBase() {
                 594..609,
                 // We use the kotlin gc
                 903..916,
-                // Current state
-                1002..1055,
             )
         }
 


### PR DESCRIPTION
## Description
This pull request improves the handling of debug information and source name deduplication in the Lua compiler and runtime, ensuring compatibility with Lua 5.4's behavior for stripped functions and chunk serialization. It introduces a utility for stripping debug info, updates chunk reading and writing logic for source names, and refines how debug and upvalue information is exposed to Lua code.

**Debug Information Stripping and Exposure:**
- Added a new utility `DebugInfoStripping` to recursively strip debug information from compiled Lua functions, used in both the CLI compiler and `string.dump()`. This ensures local variable names, line mappings, and upvalue names (except `_ENV`) are removed, while line definition info is preserved for debugging. [[1]](diffhunk://#diff-ad5f5503f0906e9dd73921e2033c0766875e6bbc518e613b7a4bfc16566d5d1eR1-R56) [[2]](diffhunk://#diff-a901f16f63ac0081051a7db4696f5059936584fed21e8cdb628e08572994de9bL106-R106) [[3]](diffhunk://#diff-6f24574ee7cc51ed9ae04ebcbf16f648da58df5f9396cbd5d0cea2bbde6f18c4L361-R362)
- Updated the `debug` library to reflect stripped debug info: `debug.getinfo(..., "L")` now only reports actual executable lines, and upvalue names for stripped functions show as `"(no name)"` instead of an empty string. [[1]](diffhunk://#diff-1d7dd6a3ec3061f51fa67f15a370d6f92014bd0014bbe913c735a70a01e798f9L463-L475) [[2]](diffhunk://#diff-1d7dd6a3ec3061f51fa67f15a370d6f92014bd0014bbe913c735a70a01e798f9R678-R688) [[3]](diffhunk://#diff-1d7dd6a3ec3061f51fa67f15a370d6f92014bd0014bbe913c735a70a01e798f9R701-R713)

**Chunk Serialization and Source Name Deduplication:**
- Modified `ChunkWriter` and `ChunkReader` to deduplicate source names for nested functions (writing an empty string if the source matches the parent), matching Lua 5.4's chunk format. Reading and writing functions now pass parent source names to properly reconstruct the source field. [[1]](diffhunk://#diff-560534c0490075c8c80bba8a0b256e998f5313b00dcbd5cb4892c100be033047L98-R107) [[2]](diffhunk://#diff-560534c0490075c8c80bba8a0b256e998f5313b00dcbd5cb4892c100be033047L221-R226) [[3]](diffhunk://#diff-560534c0490075c8c80bba8a0b256e998f5313b00dcbd5cb4892c100be033047L239-R245) [[4]](diffhunk://#diff-5071df99dd40fcdc683171bb425ce3d902ae351d3dacb644b15357fa4901adc3L32-R33) [[5]](diffhunk://#diff-5071df99dd40fcdc683171bb425ce3d902ae351d3dacb644b15357fa4901adc3R73-R82) [[6]](diffhunk://#diff-5071df99dd40fcdc683171bb425ce3d902ae351d3dacb644b15357fa4901adc3L94-R99) [[7]](diffhunk://#diff-5071df99dd40fcdc683171bb425ce3d902ae351d3dacb644b15357fa4901adc3R144) [[8]](diffhunk://#diff-5071df99dd40fcdc683171bb425ce3d902ae351d3dacb644b15357fa4901adc3R164-R166)

**Compiler and CLI Improvements:**
- Updated the CLI `luac` command to use the new debug info stripping utility, simplifying code and ensuring consistent behavior with the runtime. [[1]](diffhunk://#diff-a901f16f63ac0081051a7db4696f5059936584fed21e8cdb628e08572994de9bR6-L8) [[2]](diffhunk://#diff-a901f16f63ac0081051a7db4696f5059936584fed21e8cdb628e08572994de9bL106-R106)
- Improved the compiler to emit line events for the function's `lastLineDefined` (the 'end' line), ensuring the set of active lines matches Lua 5.4, especially for non-stripped functions. [[1]](diffhunk://#diff-ef8b039a4135f1ddd84c5600bb5da9d4576b84bc42269f620bb9826e934bc692R10-R11) [[2]](diffhunk://#diff-ef8b039a4135f1ddd84c5600bb5da9d4576b84bc42269f620bb9826e934bc692R307-R315)

**Documentation:**
- Enhanced the `README.md` with a detailed checklist of Lua test suite coverage, clarifying which tests are passing, partial, failing, or skipped.
<!-- Brief description of your changes -->

## Type of Change
<!-- Format PR title as: <type>(<scope>): <description> -->
<!-- Example: feat(vm): add trampolining for all calls -->

- [x] `fix:` Bug fix
- [ ] `feat:` New feature
- [ ] `feat!:` Breaking change
- [ ] `refactor:` Code restructuring
- [ ] `docs:` Documentation
- [ ] `test:` Tests
- [ ] `perf:` Performance
- [ ] `chore:` Maintenance

## Related Issues
Closes #

## Testing
- [x] All tests pass
- [x] New tests added (if applicable)

---
**By submitting this PR, I confirm my contribution is made under the project's license.**
